### PR TITLE
2565 last call adjustments.

### DIFF
--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -15,47 +15,35 @@ requires: 198
 This EIP reprices the [EIP-198](./eip-198.md) ‘big integer modular exponentiation’, or `ModExp`, precompile.
 
 ## Abstract
-To improve the gas cost pricing of the `ModExp` precompile, this EIP specifies:
-
-1. A change to the `mult_complexity` formula to better reflect the computational complexity of ModExp operations
-2. A change to the value of the `GQUADDIVISOR` parameter in the ModExp pricing formula to bring its costs in-line with other precompiles
-3. A minimum cost to call the precompile to prevent underpricing for small inputs
+To accurately reflect the real world operational cost of the `ModExp` precompile, this EIP specifies an algorithm for calculating the gas cost.
+This algorithm approximates the multiplication complexity cost and multiplies that by an approximation of the iterations required to execute the exponentiation.
 
 ## Motivation
 Modular exponentiation is a foundational arithmetic operation for many cryptographic functions including signatures, VDFs, SNARKs, accumulators, and more. Unfortunately, the ModExp precompile is currently over-priced, making these operations inefficient and expensive. By reducing the cost of this precompile, these cryptographic functions become more practical, enabling improved security, stronger randomness (VDFs), and more.
 
 ## Specification
-The current gas pricing formula is defined in [EIP-198](./eip-198.md) as follows: 
-
+As of `FORK_BLOCK_NUMBER`, the gas cost of calling the precompile at address `0x0000000000000000000000000000000000000005` will be calculated as follows:
 ```
-floor(mult_complexity(max(length_of_MODULUS, length_of_BASE)) * max(ADJUSTED_EXPONENT_LENGTH, 1) / GQUADDIVISOR)
+def calculate_iteration_complexiyt(base_length, modulus_length):
+    max_length = max(base_length, modulus_length)
+    words = ceiling(max_length / 8)
+    return words^2
+
+def calculate_iteration_count(exponent):
+    exponent_length = ??? # TODO: is there an easy way to get the bit length of an number in python?
+    approximate_iteration_count = max(???, 1) # TODO: figure out how to express this clearly in python
+    
+def calculate_gas_cost(base_length, modulus_length, exponent):
+    iteration_complexity = calculate_multiplication_complexity(base_length, modulus_length
+    iteration_count = calculate_iteration_count(exponent)
+    return max(200, floor(iteration_complexity * iteration_count / 3))
 ```
-
-As of `FORK_BLOCK_NUMBER` make the following changes to the pricing formula for the ModExp precompile:
-
-### 1: Modify the `mult_complexity` function
-Replace the `mult_complexity` functon with the following formula to better estimate the computational complexity for varying input values:
-
-```
-def mult_complexity(x):
-    ceiling(x/8)^2
-```
-where is `x` is `max(length_of_MODULUS, length_of_BASE)`. 
-
-### 2. Update value of `GQUADDIVISOR`
-Update the value of `GQUADDIVISOR` to `3`.
-
-### 3. Set a minimum price for calling the precompile
-Wrap the function to ensure a minimum gas price of `200`, i.e:
- `
-max(200,floor(mult_complexity(max(length_of_MODULUS, length_of_BASE)) * max(ADJUSTED_EXPONENT_LENGTH, 1) / GQUADDIVISOR))
-`
 
 ## Rationale
 After benchmarking the ModExp precompile, we discovered that it is ‘overpriced’ relative to other precompiles. We also discovered that the current gas pricing formula could be improved to better estimate the computational complexity of various ModExp input variables. The following changes improve the accuracy of the `ModExp` pricing:
 
 ### 1. Modify ‘computational complexity’ formula to better reflect the computational complexity
-The current complexity function, as defined in EIP-198 is as follow:
+The complexity function defined in [EIP-198](./eip-198.md) is as follow:
 
 ```
 def mult_complexity(x):
@@ -65,14 +53,14 @@ def mult_complexity(x):
 ```
 where is `x` is `max(length_of_MODULUS, length_of_BASE)`
 
-This complexity formula was meant to approximate the difficulty of Karatsuba multiplication. However, we found a better approximation for modelling modular exponentiation. In the new complexity formula `x` is divided by 8 to account for the number of limbs in multiprecision arithmetic. A comparison of the current ‘complexity’ function and the proposed function against the execution time can be seen below:
+The complexity formula in [EIP-198](./eip-198.md) was meant to approximate the difficulty of Karatsuba multiplication. However, we found a better approximation for modelling modular exponentiation. In the complexity formula defined in this EIP, `x` is divided by 8 to account for the number of limbs in multiprecision arithmetic. A comparison of the current ‘complexity’ function and the proposed function against the execution time can be seen below:
 
 ![Option 1 Graph](../assets/eip-2565/Complexity_Regression.png)
 
-The new complexity function has a better fit vs. the execution time when compared to the current complexity function. This better fit is because the new complexity formula accounts for the use of binary exponentiation algorithms that are used by ‘bigint’ libraries for large exponents. You may also notice the regression line of the proposed complexity function bisects the test vector data points. This is because the run time varies depending on if the modulus is even or odd.
+The complexity function defined here has a better fit vs. the execution time when compared to the [EIP-198](./eip-198.md) complexity function. This better fit is because this complexity formula accounts for the use of binary exponentiation algorithms that are used by ‘bigint’ libraries for large exponents. You may also notice the regression line of the proposed complexity function bisects the test vector data points. This is because the run time varies depending on if the modulus is even or odd.
 
 ### 2. Change the value of GQUADDIVISOR
-After changing the 'computational complexity' formula it is necessary to change `QGUADDIVSOR` to bring the gas costs inline with their runtime. We recommend changing the value from '20' to '3'. With this change, the cost of the ModExp precompile will have a higher cost (gas/second) than other precompiles such as ECRecover.
+After changing the 'computational complexity' formula in [EIP-198](./eip-198.md) to the one defined here it is necessary to change `QGUADDIVSOR` to bring the gas costs inline with their runtime. By setting the `QGUADDIVISOR` to `3` the cost of the ModExp precompile will have a higher cost (gas/second) than other precompiles such as ECRecover.
 
 ![Option 2 Graph](../assets/eip-2565/GQuad_Change.png)
 
@@ -82,7 +70,7 @@ This prevents the precompile from underpricing small input values.
 ## Test Cases
 There are no changes to the underlying interface or arithmetic algorithms, so the existing test vectors can be reused. Below is a table with the updated test vectors:
 
-| Test Case  | EIP-198 Pricing | New Pricing |
+| Test Case  | EIP-198 Pricing | EIP-2565 Pricing |
 | ------------- | ------------- | ------------- |
 | modexp_nagydani_1_square | 204  | 200  |
 | modexp_nagydani_1_qube | 204  | 200  |
@@ -100,11 +88,11 @@ There are no changes to the underlying interface or arithmetic algorithms, so th
 | modexp_nagydani_5_qube  | 17868  | 5461  |
 | modexp_nagydani_5_pow0x10001  | 285900 | 87381  |
 
-## Security Considerations
-The biggest security consideration for this EIP is creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
-
 ## Implementations
 [Geth](https://github.com/ethereum/go-ethereum/pull/21607)
+
+## Security Considerations
+The biggest security consideration for this EIP is creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
@ineffectualproperty Rather than continuing to go back and forth, I thought maybe just submitting a PR that expresses my recommendations would be easier.

The entire gas algorithm is encoded in this EIP without needing to reference 198.
Other sections were also adjusted to no longer reference 198.
Also removed unnecessary variables like `GQUADDIVISOR`, since that can just be baked into the algorithm and we don't need to talk about it separately (just like the squaring is baked in without defining a special variable that just means `2`).

Notes:
1. There are a couple of TODOs left in, I figure you'll be better able to address them than I.
2. Verify that the algorithm I wrote up is accurate!  I tried figure it out from this EIP and 198, but it was tough because neither just clearly defined the algorithm in code in a single place.
3. I recommend updating the images if possible to mention EIP-198 and EIP-2565 rather than "current" and "proposed".